### PR TITLE
Made social media links in the navigation menu visible

### DIFF
--- a/static/about.html
+++ b/static/about.html
@@ -83,7 +83,7 @@
             width="100px"
             class="mb-2"
             alt="CISSA"
-          /> 
+          />
         </a>
         <button
           class="navbar-toggler"
@@ -120,18 +120,18 @@
               <div class="dropdown-menu" aria-labelledby="navbarDropdown">
                 <a class="dropdown-item" href="https://medium.com/cissa-unimelb"
                 ><i class="fab fa-medium-m"></i
-              ></a>
+              >cissa-unimelb</a>
               <a
                 class="dropdown-item"
                 href="https://www.facebook.com/cissa.unimelb/"
                 ><i class="fab fa-facebook-f"></i
-              ></a>
+              >cissa.unimelb</a>
               <a class="dropdown-item" href="https://instagram.com/cissa_unimelb/"
                 ><i class="fab fa-instagram"></i
-              ></a>
+              >cissa_unimelb</a>
               <a class="dropdown-item" href="https://twitter.com/cissa_unimelb/"
                 ><i class="fab fa-twitter"></i
-              ></a>
+              >cissa_unimelb</a>
               </div>
             </li>
           </ul>
@@ -148,15 +148,15 @@
       <h3 class="my-5">Who are we?</h3>
       <div class="row">
         <p class="cissa-intro col-lg-6">
-          The Computing and Information Systems Students Association (CISSA) represents the IT and tech-oriented 
-          student community at the University of Melbourne. For those studying Computer Science, Software Engineering, 
-          Information Technology or Information Systems, we believe joining CISSA is a must, and of course  
-          we welcome students from different academic backgrounds too! Since our founding in 1992, we have seen more than 
+          The Computing and Information Systems Students Association (CISSA) represents the IT and tech-oriented
+          student community at the University of Melbourne. For those studying Computer Science, Software Engineering,
+          Information Technology or Information Systems, we believe joining CISSA is a must, and of course
+          we welcome students from different academic backgrounds too! Since our founding in 1992, we have seen more than
           5,000 students join the club! In 2019, CISSA saw enormous growth, welcoming over 1,300 students to our community.
-          In 2020, CISSA will remain as committed as ever to fostering an accepting and warm community for students of all 
-          backgrounds and identities. So don't hestitate to get into contact with us, our committee is extremely friendly and 
+          In 2020, CISSA will remain as committed as ever to fostering an accepting and warm community for students of all
+          backgrounds and identities. So don't hestitate to get into contact with us, our committee is extremely friendly and
           approachable. We loook forward to sharing the exciting year ahead of us with you!
-        </p>   
+        </p>
 
         <div class="col-lg-6 text-center py-2">
           <img class="img-about" src="assets/images/cute.jpg" alt="Photo"/>
@@ -166,8 +166,8 @@
       <h3 class="my-5">What do we do?</h3>
       <div class="row">
         <div class="cissa-intro col-lg-6 ">
-          To bridge the gap between university and industry, we hold social, industry and networking events regularly. Whether you are looking 
-          for academic courses or searching for work opportunities in different IT-related areas, CISSA is the place to go. 
+          To bridge the gap between university and industry, we hold social, industry and networking events regularly. Whether you are looking
+          for academic courses or searching for work opportunities in different IT-related areas, CISSA is the place to go.
           Also, if you are more of a hands-on type of person, you will enjoy Codebrew, our annual hackathon. <a href="events.html"><u>Check out our
           upcoming events!</u></a>
         </div>
@@ -181,7 +181,7 @@
       <a href="https://cissa.org.au/signup" target="_blank" class="signup text-center sign-up-btn btn btn-dark btn-squared">Sign up Now!</a>
     </div>
     </div>
-  
+
 
 
 
@@ -261,7 +261,7 @@
         </div>
       </div>
     </div>
-    
+
     <div class="row dark text-center d-flex justify-content-center section footer pt-5 pb-3">
         <img src="assets/images/cissa_white.svg" class="col-md-4" alt="CISSA"/>
         <div class="footer-img col-md-6">

--- a/static/assets/css/main.css
+++ b/static/assets/css/main.css
@@ -58,9 +58,20 @@ html, body{
   transition: width .5s;
 }
 
-.dropdown-menu{
+.dropdown-menu {
   background-color: #020A23;
 }
+
+.dropdown-item {
+  color: white;
+}
+
+.dropdown-item .fab {
+  width: 1em;
+  text-align: center;
+  margin-right: 0.5em;
+}
+
 .sponsors {
   max-height: 115px;
   max-width: 250px;
@@ -401,7 +412,7 @@ hr{
     text-align: center;
     margin:0 auto;
   }
-  
+
 }
 
 @media only screen and (max-width: 768px) {

--- a/static/contact.html
+++ b/static/contact.html
@@ -120,18 +120,18 @@
               <div class="dropdown-menu" aria-labelledby="navbarDropdown">
                 <a class="dropdown-item" href="https://medium.com/cissa-unimelb"
                 ><i class="fab fa-medium-m"></i
-              ></a>
+              >cissa-unimelb</a>
               <a
                 class="dropdown-item"
                 href="https://www.facebook.com/cissa.unimelb/"
                 ><i class="fab fa-facebook-f"></i
-              ></a>
+              >cissa.unimelb</a>
               <a class="dropdown-item" href="https://instagram.com/cissa_unimelb/"
                 ><i class="fab fa-instagram"></i
-              ></a>
+              >cissa_unimelb</a>
               <a class="dropdown-item" href="https://twitter.com/cissa_unimelb/"
                 ><i class="fab fa-twitter"></i
-              ></a>
+              >cissa_unimelb</a>
               </div>
             </li>
           </ul>
@@ -191,7 +191,7 @@
         else{
           await axios.post('https://api.cissa.org.au/contact', {
           ...formData,
-          
+
           recipient: 'executives@cissa.org.au'});
           document.getElementById('result').innerHTML = '<font color="green">Message Sent. We will be in touch soon!</font>';
           window.scrollTo(0, 0);

--- a/static/events.html
+++ b/static/events.html
@@ -83,7 +83,7 @@
             width="100px"
             class="mb-2"
             alt="CISSA"
-          /> 
+          />
         </a>
         <button
           class="navbar-toggler"
@@ -120,18 +120,18 @@
               <div class="dropdown-menu" aria-labelledby="navbarDropdown">
                 <a class="dropdown-item" href="https://medium.com/cissa-unimelb"
                 ><i class="fab fa-medium-m"></i
-              ></a>
+              >cissa-unimelb</a>
               <a
                 class="dropdown-item"
                 href="https://www.facebook.com/cissa.unimelb/"
                 ><i class="fab fa-facebook-f"></i
-              ></a>
+              >cissa.unimelb</a>
               <a class="dropdown-item" href="https://instagram.com/cissa_unimelb/"
                 ><i class="fab fa-instagram"></i
-              ></a>
+              >cissa_unimelb</a>
               <a class="dropdown-item" href="https://twitter.com/cissa_unimelb/"
                 ><i class="fab fa-twitter"></i
-              ></a>
+              >cissa_unimelb</a>
               </div>
             </li>
           </ul>
@@ -144,7 +144,7 @@
     </div>
 
     <h3 class="section-title text-center mt-4 mb-2 py-4">
-    Upcoming Events 
+    Upcoming Events
     </h3>
     <div class="pt-5 text-center no-events">
     There are no upcoming events. Come back later!

--- a/static/gallery.html
+++ b/static/gallery.html
@@ -88,7 +88,7 @@
             width="100px"
             class="mb-2"
             alt="CISSA"
-          /> 
+          />
         </a>
         <button
           class="navbar-toggler"
@@ -125,18 +125,18 @@
               <div class="dropdown-menu" aria-labelledby="navbarDropdown">
                 <a class="dropdown-item" href="https://medium.com/cissa-unimelb"
                 ><i class="fab fa-medium-m"></i
-              ></a>
+              >cissa-unimelb</a>
               <a
                 class="dropdown-item"
                 href="https://www.facebook.com/cissa.unimelb/"
                 ><i class="fab fa-facebook-f"></i
-              ></a>
+              >cissa.unimelb</a>
               <a class="dropdown-item" href="https://instagram.com/cissa_unimelb/"
                 ><i class="fab fa-instagram"></i
-              ></a>
+              >cissa_unimelb</a>
               <a class="dropdown-item" href="https://twitter.com/cissa_unimelb/"
                 ><i class="fab fa-twitter"></i
-              ></a>
+              >cissa_unimelb</a>
               </div>
             </li>
           </ul>

--- a/static/index.html
+++ b/static/index.html
@@ -117,18 +117,18 @@
               <div class="dropdown-menu" aria-labelledby="navbarDropdown">
                 <a class="dropdown-item" href="https://medium.com/cissa-unimelb"
                 ><i class="fab fa-medium-m"></i
-              ></a>
+              >cissa-unimelb</a>
               <a
                 class="dropdown-item"
                 href="https://www.facebook.com/cissa.unimelb/"
                 ><i class="fab fa-facebook-f"></i
-              ></a>
+              >cissa.unimelb</a>
               <a class="dropdown-item" href="https://instagram.com/cissa_unimelb/"
                 ><i class="fab fa-instagram"></i
-              ></a>
+              >cissa_unimelb</a>
               <a class="dropdown-item" href="https://twitter.com/cissa_unimelb/"
                 ><i class="fab fa-twitter"></i
-              ></a>
+              >cissa_unimelb</a>
               </div>
             </li>
           </ul>
@@ -233,7 +233,7 @@
     </div>
 
     <script>
-      
+
 
 
 

--- a/static/past_events.html
+++ b/static/past_events.html
@@ -83,7 +83,7 @@
             width="100px"
             class="mb-2"
             alt="CISSA"
-          /> 
+          />
         </a>
         <button
           class="navbar-toggler"
@@ -120,18 +120,18 @@
               <div class="dropdown-menu" aria-labelledby="navbarDropdown">
                 <a class="dropdown-item" href="https://medium.com/cissa-unimelb"
                 ><i class="fab fa-medium-m"></i
-              ></a>
+              >cissa-unimelb</a>
               <a
                 class="dropdown-item"
                 href="https://www.facebook.com/cissa.unimelb/"
                 ><i class="fab fa-facebook-f"></i
-              ></a>
+              >cissa.unimelb</a>
               <a class="dropdown-item" href="https://instagram.com/cissa_unimelb/"
                 ><i class="fab fa-instagram"></i
-              ></a>
+              >cissa_unimelb</a>
               <a class="dropdown-item" href="https://twitter.com/cissa_unimelb/"
                 ><i class="fab fa-twitter"></i
-              ></a>
+              >cissa_unimelb</a>
               </div>
             </li>
           </ul>
@@ -140,7 +140,7 @@
     </div>
 
     <h3 class="section-title text-center mt-4 mb-2 py-4">Past Events </h3>
-    <div class="row"> 
+    <div class="row">
       <div class="col-md-6">
         <div id="event2" class="event-img text-center py-5">
           <img src="assets/images/optiver_IC.png" alt="Photo"/>
@@ -149,7 +149,7 @@
         <div class="text-center event-descr pt-1 pb-5">
             <h4>Industry Connect Series: Optiver</h4>
             <p>
-            As an engineer at Optiver, you'll work at the cutting edge on a high performance, low latency global network handling petabytes of data. 
+            As an engineer at Optiver, you'll work at the cutting edge on a high performance, low latency global network handling petabytes of data.
             With advanced trading technology and connections to markets, you'll be working with an innovative team on a leading infrastructure.
             During our online talk, you'll hear a range of perspectives on software and hardware devolvement, production engineering and life at a trading firm.
             As part of our Networking Week, you'll also have the opportunity to ask any questions - so come prepared!
@@ -174,8 +174,8 @@
         <div  class="text-center event-descr pt-1 pb-5">
             <h4>EY Tech Talk</h4>
             <p>
-            Stuck inside? Join us online for a talk with EY, a leader of digital transformations for organisations all over the world. 
-            You'll learn about how they define strategies, improve user experiences and deliver solutions using a breadth of technologies, including advanced data analytics, IoT, blockchain and AI. 
+            Stuck inside? Join us online for a talk with EY, a leader of digital transformations for organisations all over the world.
+            You'll learn about how they define strategies, improve user experiences and deliver solutions using a breadth of technologies, including advanced data analytics, IoT, blockchain and AI.
             As part of our networking week, you'll also have the opportunity to ask questions, network and hear from recent graduates about what makes a successful technologist at EY.
             </p>
             <div>
@@ -199,8 +199,8 @@
         <div class="text-center event-descr pt-1 pb-5">
             <h4>WISE & CISSA BBQ</h4>
             <p>
-            Let's chill on the Peter Hall Lawn and bond over some BBQ! 
-            Our friends at Women in Science and Engineering (WISE) will be there too. Get involved! 
+            Let's chill on the Peter Hall Lawn and bond over some BBQ!
+            Our friends at Women in Science and Engineering (WISE) will be there too. Get involved!
             <a href="https://www.wiseunimelb.com/">https://www.wiseunimelb.com/</a>
             </p>
             <div>
@@ -222,10 +222,10 @@
         <div class="text-center event-descr pt-1 pb-5">
             <h4>Microsoft Protégé Case Competition Workshop</h4>
             <p>
-            Microsoft will be on campus to run a workshop on their ongoing technology 
-            case competition, Protégé 2020. Teams of 1-4 from any faculty have the chance to apply their analytical 
-            and tech skills to this year's bushfire relief case. Winning teams from around Australia will be invited to an exclusive three-day 
-            event at Microsoft's Sydney locations and take home Microsoft products. On the 6th of March, Microsoft will 
+            Microsoft will be on campus to run a workshop on their ongoing technology
+            case competition, Protégé 2020. Teams of 1-4 from any faculty have the chance to apply their analytical
+            and tech skills to this year's bushfire relief case. Winning teams from around Australia will be invited to an exclusive three-day
+            event at Microsoft's Sydney locations and take home Microsoft products. On the 6th of March, Microsoft will
             provide inspiration and mentorship to kick-start your team's success. They'll even treat you to food during lunch!
             </p>
             <div>
@@ -248,7 +248,7 @@
         <div class="text-center event-descr pt-1 pb-5">
             <h4>Jane Street Estimathon & Info Session</h4>
             <p>
-            Join Jane Street for an informative look into the world of trading and technology, and learn about our job opportunities! 
+            Join Jane Street for an informative look into the world of trading and technology, and learn about our job opportunities!
             We will also play a mathematically driven game called Estimathon. Food and drinks will be served.
             </p>
             <div>
@@ -272,10 +272,10 @@
         <div class="text-center event-descr pt-1 pb-5">
             <h4>Improving the Market: Optiver’s Approach to Hard Problems</h4>
             <p>
-            Software Engineers at Optiver will come to campus and share their passions in improve the market 
-            and their wisdoms in the difficult technical, architectural challenges involved, and the approaches 
-            that have proven to be particularly effective in dealing with them. You'll learn about Optiver's 
-            graduate and intern opportunities, their culture, and some recent projects. You'll also get a 
+            Software Engineers at Optiver will come to campus and share their passions in improve the market
+            and their wisdoms in the difficult technical, architectural challenges involved, and the approaches
+            that have proven to be particularly effective in dealing with them. You'll learn about Optiver's
+            graduate and intern opportunities, their culture, and some recent projects. You'll also get a
             little insight into Ready Trader One, Optiver's algorithmic trading competition beginning on March 9.
             </p>
             <div>
@@ -298,14 +298,14 @@
         <div class="text-center event-descr pt-1 pb-5">
             <h4>Welcome Back Day Expo</h4>
             <p>
-                We will be hosting a Welcome Back session on the South Lawn tomorrow at 12pm! 
-                It is a perfect opportunity to meet new friends and your future teammates for our upcoming hackathons. 
-                For goody-grabbers and job seekers, it's your time to shine! Our committees have great source recruitment 
-                information and packed amounts of brochures & goodies which we are excited to share. 
-                Be sure to check them out! 
+                We will be hosting a Welcome Back session on the South Lawn tomorrow at 12pm!
+                It is a perfect opportunity to meet new friends and your future teammates for our upcoming hackathons.
+                For goody-grabbers and job seekers, it's your time to shine! Our committees have great source recruitment
+                information and packed amounts of brochures & goodies which we are excited to share.
+                Be sure to check them out!
             </p>
             <div>
-            Time: 2 March 2020 12:00-13:00 
+            Time: 2 March 2020 12:00-13:00
             </div>
             <div>
             Location: @ South Lawn
@@ -326,7 +326,7 @@
             <p>
             Hi Everyone! The wait is finally over! We are excited to introduce our first event of 2020. Come and chat to us
             at the club festival hosted by the Science Faculty and familiarise yourself with learning opportunities and career
-            options in the tech industry. 
+            options in the tech industry.
 
             P.s you may also get a sneak-peak of our event roadmap!
             </p>

--- a/static/sponsors.html
+++ b/static/sponsors.html
@@ -123,18 +123,18 @@
               <div class="dropdown-menu" aria-labelledby="navbarDropdown">
                 <a class="dropdown-item" href="https://medium.com/cissa-unimelb"
                 ><i class="fab fa-medium-m"></i
-              ></a>
+              >cissa-unimelb</a>
               <a
                 class="dropdown-item"
                 href="https://www.facebook.com/cissa.unimelb/"
                 ><i class="fab fa-facebook-f"></i
-              ></a>
+              >cissa.unimelb</a>
               <a class="dropdown-item" href="https://instagram.com/cissa_unimelb/"
                 ><i class="fab fa-instagram"></i
-              ></a>
+              >cissa_unimelb</a>
               <a class="dropdown-item" href="https://twitter.com/cissa_unimelb/"
                 ><i class="fab fa-twitter"></i
-              ></a>
+              >cissa_unimelb</a>
               </div>
             </li>
           </ul>


### PR DESCRIPTION
Just a random unimelb student here - I was on the CISSA website and noticed none of the social media links were visible because of dark text on a dark background, and I thought I ought to try fix that real quick.

I noticed my PR also seems to have removed trailing whitespace in some files (probably my editor doing that on save oops). Let me know if this is unwanted - I can probably redo the commit