### PR TITLE
Fix Canva sponsor div alignment

### DIFF
--- a/static/sponsors.html
+++ b/static/sponsors.html
@@ -159,7 +159,7 @@
             /></picture>
           </div>
 
-          <div class="col-md-5 text-center py-5 my-auto">
+          <div class="col-md-6 text-center py-5 my-auto">
             <picture>
               <img
                 src="assets/images/sponsors/imc.png"
@@ -169,13 +169,15 @@
             </picture>
           </div>
 
-          <div class="col-md-5 text-center py-5 my-auto">
+          <div class="col-md-6 text-center py-5 my-auto">
             <picture>
-              <img
-                src="assets/images/sponsors/canva.png"
-                class="sponsors"
-                alt="Canva"
-              />
+              <a href="https://canva.com/careers">
+                <img
+                  src="assets/images/sponsors/canva.png"
+                  class="sponsors"
+                  alt="Canva"
+                />
+              <a/>
             </picture>
           </div>
 


### PR DESCRIPTION
Fixes an issue with rendering of certain sponsor logos. Because the parent column is a col-md-12, having two child divs be col-md-5 instead of col-md-6 left them slightly off centre. This PR corrects this issue. I've also taken the liberty of adding a link to the Canva image (because I know where it should be directed), I'd suggest you do the same for the others (as I can't speak to where they should be linked, though I'd suggest a careers page, or failing that just the sponsor home page).
Before:
<img width="927" alt="Screen Shot 2021-03-27 at 9 42 46 am" src="https://user-images.githubusercontent.com/9084563/112700628-acee8d00-8ee2-11eb-9586-ec704997ad41.png">
After:
<img width="926" alt="Screen Shot 2021-03-27 at 9 43 53 am" src="https://user-images.githubusercontent.com/9084563/112700645-b4ae3180-8ee2-11eb-8b84-a981e6c9f313.png">
